### PR TITLE
Adds Install flag in CMakeLists.txt for gpr_build

### DIFF
--- a/source/app/gpr_tools/CMakeLists.txt
+++ b/source/app/gpr_tools/CMakeLists.txt
@@ -41,6 +41,11 @@ endif(EXISTS "${CMAKE_SOURCE_DIR}/source/lib/tiny_jpeg")
 # add executable
 add_executable( ${EXE_NAME} ${GPRTOOLS_SRC_FILES} ${GPRTOOLS_INC_FILES} )
 
+install(TARGETS gpr_tools
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib/static)
+
 # Linked libraries
 target_link_libraries( ${EXE_NAME} gpr_sdk )
 


### PR DESCRIPTION
This allows to run `make install` after `cmake .. && make` to copy gpr_tools to /usr/loca/bin, so gpr_tools can be used system-wide.