### PR TITLE
clean unused var and made for loop more readable

### DIFF
--- a/source/app/common/argument_parser/argument_parser.cpp
+++ b/source/app/common/argument_parser/argument_parser.cpp
@@ -56,10 +56,9 @@ void argument_parser::set_options()
 
 int argument_parser::parse(int argc, char *argv [], const char* application_text, const char* prefix_text)
 {
-    application_path = argv[0];
     argument_count = argc;
     
-    for (int i = 0; i < argc; i++)
+    for (int i = 0; i < argument_count; i++)
         arguments[i] = argv[i];
     
     set_options();


### PR DESCRIPTION
Cleaned unused var for argv[0] from the code and used the preassigned var of argc in the for loop the make it more readable  