### PR TITLE
Include strings.h

### DIFF
--- a/source/app/gpr_tools/main_c.c
+++ b/source/app/gpr_tools/main_c.c
@@ -17,6 +17,7 @@
  */
 
 #include <stdio.h>
+#include <strings.h>
 #include <string.h>
 #include <stdbool.h>
 


### PR DESCRIPTION
I am on Manjaro Linux 6.1.

I am not a C programmer, and I only wanted to get this to work on my end. Not sure why I was getting errors without strings.h

I was getting this error when building from source:

```
error: implicit declaration of function ‘strcasecmp’; did you mean ‘strncmp’? [-Wimplicit-function-declaration]
   26 | #define stricmp strcasecmp
```

Replacing string.h with strings.h does not work either.

Adding strings.h fixes this issue for me and I am able to convert GPR to DNG smoothly.