### PR TITLE
Fix submodule compatibility by switching to CMAKE_CURRENT_SOURCE_DIR in CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,24 +8,24 @@ set(CMAKE_C_FLAGS "-std=c99")
 # project name
 project( gpr )
 
-if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
   execute_process(
     COMMAND git rev-parse --abbrev-ref HEAD
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     OUTPUT_VARIABLE GIT_BRANCH
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 
   execute_process(
     COMMAND git log -1 --format=%h
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     OUTPUT_VARIABLE GIT_COMMIT_HASH
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
-else(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+else(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
   set(GIT_BRANCH "")
   set(GIT_COMMIT_HASH "")
-endif(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+endif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
 
 message(STATUS "Git current branch: ${GIT_BRANCH}")
 message(STATUS "Git commit hash: ${GIT_COMMIT_HASH}")
@@ -37,21 +37,21 @@ add_definitions("-DGIT_BRANCH=\"${GIT_BRANCH}\"")
 add_subdirectory( "source/lib/common" )
 add_subdirectory( "source/lib/vc5_common" )
 
-if(EXISTS "${CMAKE_SOURCE_DIR}/source/lib/vc5_decoder")
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/source/lib/vc5_decoder")
   MESSAGE( STATUS "Found source/lib/vc5_decoder - enabling vc5 decoder and setting GPR_READING=1" )
   add_subdirectory( "source/lib/vc5_decoder" )
   add_subdirectory( "source/app/vc5_decoder_app" )
-else(EXISTS "${CMAKE_SOURCE_DIR}/source/lib/vc5_decoder")
+else(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/source/lib/vc5_decoder")
   MESSAGE( STATUS "Could not find source/lib/vc5_decoder - disabling vc5 decoder and setting GPR_READING=0" )
-endif(EXISTS "${CMAKE_SOURCE_DIR}/source/lib/vc5_decoder")
+endif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/source/lib/vc5_decoder")
 
-if(EXISTS "${CMAKE_SOURCE_DIR}/source/lib/vc5_encoder")
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/source/lib/vc5_encoder")
   MESSAGE( STATUS "Found source/lib/vc5_encoder - enabling vc5 encoder and setting GPR_WRITING=1" )
   add_subdirectory( "source/lib/vc5_encoder" )
   add_subdirectory( "source/app/vc5_encoder_app" )
-else(EXISTS "${CMAKE_SOURCE_DIR}/source/lib/vc5_encoder")
+else(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/source/lib/vc5_encoder")
   MESSAGE( STATUS "Could not find source/lib/vc5_encoder - disabling vc5 encoder and setting GPR_WRITING=0" )
-endif(EXISTS "${CMAKE_SOURCE_DIR}/source/lib/vc5_encoder")
+endif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/source/lib/vc5_encoder")
 
 add_subdirectory( "source/lib/dng_sdk" )
 add_subdirectory( "source/lib/gpr_sdk" )
@@ -59,12 +59,12 @@ add_subdirectory( "source/lib/xmp_core" )
 add_subdirectory( "source/lib/expat_lib" )
 add_subdirectory( "source/lib/md5_lib" )
 
-if(EXISTS "${CMAKE_SOURCE_DIR}/source/lib/tiny_jpeg")
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/source/lib/tiny_jpeg")
   MESSAGE( STATUS "Found source/lib/tiny_jpeg - enabling jpeg writing and setting GPR_JPEG_AVAILABLE=1" )
   add_subdirectory( "source/lib/tiny_jpeg" )
-else(EXISTS "${CMAKE_SOURCE_DIR}/source/lib/tiny_jpeg")
+else(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/source/lib/tiny_jpeg")
   MESSAGE( STATUS "Could not find source/lib/tiny_jpeg - disabling jpeg writing and setting GPR_JPEG_AVAILABLE=0" )
-endif(EXISTS "${CMAKE_SOURCE_DIR}/source/lib/tiny_jpeg")
+endif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/source/lib/tiny_jpeg")
 
 add_subdirectory( "source/app/common/cJSON" )
 add_subdirectory( "source/app/common/argument_parser" )


### PR DESCRIPTION
I'm using gpr_sdk as a submodule for my research project. Changing CMAKE_SOURCE_DIR to CMAKE_CURRENT_SOURCE_DIR allows the library to find vc5_decoder, vc5_encoder, and tiny_jpeg correctly. 