### PR TITLE
Increase IMAGE_DESCRIPTION_SIZE from 32 to 64

### DIFF
--- a/source/lib/gpr_sdk/public/gpr_exif_info.h
+++ b/source/lib/gpr_sdk/public/gpr_exif_info.h
@@ -31,7 +31,7 @@
 #define SURVEY_DATA_SIZE        32
 #define PROCESSING_METHOD_SIZE  32
 #define AREA_INFORMATION_SIZE   32
-#define IMAGE_DESCRIPTION_SIZE  32
+#define IMAGE_DESCRIPTION_SIZE  64
 
 #include "gpr_platform.h"
 


### PR DESCRIPTION
Increase IMAGE_DESCRIPTION_SIZE from 32 to 64 - Fix for Issue #49