### PR TITLE
Mission 1 RAW Video and RAW stills speedup and CNN visual improvements. 

### DIFF
--- a/docs/GVID_CONTAINER.md
+++ b/docs/GVID_CONTAINER.md
@@ -1,0 +1,112 @@
+# GVID Container Sketch
+
+`.gvid` is proposed as a simple raw-video container for Labs raw media
+experiments. The intent is to store independently decodable raw Bayer frames,
+not to introduce cross-frame compression or a new image development pipeline.
+
+This document is a container sketch for review. It is not a final bitstream
+standard.
+
+## Design Goals
+
+- One raw Bayer frame per container frame.
+- No cross-frame dependency.
+- Constant-time recovery after interrupted capture.
+- Enough metadata to decode, preview, and export the stream on a host.
+- Simple append-only writer suitable for embedded storage paths.
+- Compatibility with existing GPR/VC-5 frame payloads where possible.
+- Explicit 14-bit and 16-bit Bayer metadata so host tools do not infer raw
+  precision from payload size alone.
+
+## File Layout
+
+```text
+gvid_file:
+  file_header
+  frame_index_hint?      # optional, may be absent during capture
+  frame_record[0]
+  frame_record[1]
+  ...
+  frame_record[n-1]
+  final_index?           # optional, written on clean close
+```
+
+## File Header
+
+| field | description |
+|---|---|
+| `magic` | ASCII `GVID`. |
+| `version` | Container version. |
+| `header_size` | Bytes in the file header. |
+| `width` / `height` | Stored Bayer frame dimensions. |
+| `fps_num` / `fps_den` | Intended frame rate. |
+| `pixel_format` | Bayer pixel format identifier. |
+| `bit_depth` | Sensor precision carried by the frame payload, commonly 14 or 16. |
+| `payload_kind` | Payload type, for example `gpr_vc5_frame`. |
+| `metadata_size` | Bytes of JSON or CBOR stream metadata following the fixed header. |
+
+## Frame Record
+
+| field | description |
+|---|---|
+| `sync` | Frame sync word. |
+| `frame_number` | Monotonic frame index. |
+| `timestamp_us` | Sensor or firmware timestamp. |
+| `payload_size` | Encoded payload bytes. |
+| `payload_crc32` | Payload integrity check. |
+| `metadata_size` | Optional per-frame metadata bytes. |
+| `payload` | One independently decodable raw frame. |
+
+If power is lost, a recovery scanner can walk records until the first invalid
+sync, size, or CRC. The last complete frame remains usable.
+
+## Metadata
+
+Required stream metadata:
+
+- Camera model and firmware version.
+- Sensor crop/window.
+- Bayer phase and bit depth.
+- Black level and white level.
+- Pixel format and stored bit depth, including 14-bit and 16-bit Bayer modes.
+- Capture mode ID.
+- Extension ID and extension manifest hash.
+- Lens and color metadata needed for host-side DNG/GPR export.
+
+Optional per-frame metadata:
+
+- Exposure time.
+- Analog and digital gain.
+- White balance gains.
+- Temperature.
+- IMU timestamp correlation.
+- Dropped-frame marker.
+
+## Preview
+
+The preview path should decode the same `.gvid` stream, then produce a bounded
+RGB preview surface. For Mission-style camera displays, the proposed review
+target is 1024 x 768 from a 4096 x 3072 Bayer stream.
+
+Preview output is not the primary raw deliverable. It is a camera UI path and
+should be validated separately from host-side ProRes or editable DNG/GPR export.
+
+## Receipts
+
+The writer should emit a receipt with:
+
+- File path.
+- File size.
+- Frame count.
+- Dropped frame count.
+- Output hash when feasible.
+- Sustained write throughput.
+- Median and wall-clock FPS.
+- Recovery result after truncating or scanning the tail.
+
+## Open Questions
+
+- Should metadata be JSON for debuggability or CBOR for smaller writes?
+- Should the final index be optional, required, or stored in periodic chunks?
+- Should frame payloads be byte-aligned for DMA/writev efficiency?
+- Should preview metadata be in the same file or a sidecar receipt?

--- a/docs/LABS_RAW_MEDIA_EXTENSION_API.md
+++ b/docs/LABS_RAW_MEDIA_EXTENSION_API.md
@@ -1,0 +1,224 @@
+# Labs Raw Media Extension API
+
+This proposal defines a small, reviewable extension contract for experimental
+raw media features in Labs firmware. It is intentionally scoped so it can start
+as a statically compiled Labs feature and later evolve into a signed extension
+bundle delivered over USB, Wi-Fi, or SD card.
+
+The motivating example is a compact raw Bayer video path that stores frames in a
+`.gvid` container, offers a camera-display preview path, and preserves an
+editable GPR/DNG-oriented post workflow.
+
+## Why This Fork Is Interesting
+
+This PR is intentionally small: it proposes a firmware-facing contract rather
+than asking GoPro to review the entire experimental fork at once. The fork
+behind this proposal contains a broader raw-media suite that may be useful to
+Labs firmware and SDK maintainers:
+
+- **Production-gated stills improvements.** The fork keeps three GPR still tiers
+  for 50 MP images: a smallest tier around 9.8 MB/frame, a primary tier around
+  15.1 MB/frame, and an archival tier around 27.2 MB/frame, all gated against
+  visual metrics.
+- **CNN-assisted stills latitude.** A matched 1x Bayer-in/Bayer-out CNN lets the
+  smaller still tier stay inside the visual gate, while the archival tier is
+  tight enough to need no CNN restoration. That gives users a practical
+  size/headroom choice instead of a single fixed quality point.
+- **Raw Bayer video.** The `.gvid` path stores independent GPR/VC-5-style raw
+  Bayer frame payloads with no cross-frame dependency, so interrupted capture
+  recovery and host-side DNG/GPR export stay simple.
+- **Camera display preview.** The same raw stream can drive a bounded
+  screen-resolution preview path, with receipts for FPS, dimensions, drops, and
+  UI presentation.
+- **Higher bit-depth raw support.** The fork work includes 14-bit and 16-bit
+  Bayer paths, which matters for modern larger sensors and for preserving raw
+  editing latitude beyond 12-bit action-camera stills.
+- **Offline 4K/8K reconstruction.** Host-side CNN cleanup and super-resolution
+  experiments target editable Bayer outputs and ProRes review media without
+  changing the camera-side capture contract.
+
+The ask here is for the reviewable interface that lets those ideas be evaluated
+inside Labs-style firmware constraints: explicit frame source, storage writer,
+preview surface, resource limits, and machine-readable receipts.
+
+## Goals
+
+- Keep the camera firmware in control of capture, storage, UI, power, and
+  resource limits.
+- Allow experimental raw media features to declare their ABI, capabilities,
+  resource budget, and supported camera models before activation.
+- Support Labs and Open GoPro control surfaces without requiring new physical
+  camera UI.
+- Make every capture mode produce machine-readable receipts for timing, drops,
+  storage, frame dimensions, and preview/display status.
+- Allow a first integration with no dynamic native-code loading.
+
+## Non-Goals
+
+- This is not a request for a general-purpose unsigned plugin loader.
+- This does not require third-party code execution on production cameras.
+- This does not change existing GPR still-photo compatibility.
+- This does not require changing the VC-5 bitstream format.
+
+## Deployment Model
+
+### Phase 0: Static Labs Feature
+
+The safest first step is to compile the extension implementation into Labs
+firmware and expose it only through Labs/Open GoPro commands. The manifest is
+still useful in this phase because it documents the mode contract and resource
+limits.
+
+### Phase 1: Signed Extension Bundle
+
+A later implementation can accept a signed bundle copied over USB, Wi-Fi, or SD
+card. The bundle should contain:
+
+- `manifest.json`
+- Optional static configuration and tuning tables.
+- Optional signed native module, if GoPro chooses to support native modules.
+- Test vectors and expected receipt schema versions.
+- A detached signature or signature block over the complete bundle.
+
+The camera should reject any bundle with an unsupported ABI, missing signature,
+unsupported camera model, excessive resource budget, or unknown required
+capability.
+
+## Manifest
+
+The extension manifest is JSON. A sample lives at
+`examples/labs/raw_media_extension_gvid.json` and is validated by
+`tools/validate_labs_extension_manifest.py`.
+
+Required top-level fields:
+
+| field | description |
+|---|---|
+| `schema` | Must be `gopro.labs.raw_media_extension.v1`. |
+| `id` | Reverse-DNS extension identifier. |
+| `name` | User-facing name. |
+| `abi` | Integer ABI version. |
+| `delivery` | How the extension is supplied: `static_labs_feature`, `signed_bundle`, or `firmware_builtin`. |
+| `camera_models` | Supported camera model identifiers. |
+| `requires` | Firmware capabilities the extension needs. |
+| `media_types` | Output media extensions. |
+| `capture_modes` | Declared capture/preview modes. |
+| `resource_limits` | Hard memory, timing, and write-rate budgets. |
+| `control` | Labs/Open GoPro control command surface. |
+| `receipts` | Receipt schemas emitted by capture and preview paths. |
+| `security` | Signature and execution policy. |
+
+## Firmware Capabilities
+
+The current proposal uses capability names rather than private implementation
+details:
+
+| capability | meaning |
+|---|---|
+| `raw_bayer_frame_source` | Firmware can provide a raw Bayer frame source without routing through encoded GPR files. |
+| `sd_writer` | Firmware can write the extension output through the normal camera storage path. |
+| `preview_surface` | Firmware can present a low-resolution preview surface on the camera UI path. |
+| `media_indexer` | Firmware can index the output file so users can browse, download, or delete it. |
+| `receipt_writer` | Firmware can write JSON receipts next to the captured media or expose them over the API. |
+
+## Control Surface
+
+The control surface should be compatible with both Labs scripting and Open
+GoPro HTTP/USB control.
+
+Suggested HTTP endpoints:
+
+```text
+GET  /gopro/labs/extensions
+GET  /gopro/labs/extensions/{id}
+POST /gopro/labs/extensions/{id}/configure
+POST /gopro/labs/extensions/{id}/capture/start
+POST /gopro/labs/extensions/{id}/capture/stop
+GET  /gopro/labs/extensions/{id}/status
+GET  /gopro/labs/extensions/{id}/receipt/latest
+```
+
+Suggested Labs commands:
+
+```text
+EXT?                         # list installed extensions
+EXT=org.gpr.gvid             # select extension
+EXTC=mode:gvid_4k_bayer_20   # configure mode
+EXTR=1                       # start extension recording
+EXTR=0                       # stop extension recording
+EXTS?                        # query extension status
+```
+
+Exact command names are placeholders; the important part is that the command
+surface maps to the same manifest-defined mode IDs and receipt schemas.
+
+## Receipts
+
+Each capture should emit a compact JSON receipt. Minimum fields:
+
+```json
+{
+  "schema": "gopro.labs.raw_media_capture_receipt.v1",
+  "extension_id": "org.gpr.gvid",
+  "mode_id": "gvid_4k_bayer_20",
+  "output": "GOPR0001.GVID",
+  "frames_written": 420,
+  "frames_dropped": 0,
+  "width": 4096,
+  "height": 3072,
+  "pixel_format": "rggb16",
+  "bit_depth": 16,
+  "fps_target": 20,
+  "fps_wall": 20.5,
+  "write_mbps": 109.5,
+  "storage_medium": "sd",
+  "source_kind": "sensor_dma_capture",
+  "preview": {
+    "width": 1024,
+    "height": 768,
+    "fps_wall": 24.2,
+    "ui_presented": true
+  },
+  "verdict": {
+    "capture_ready": true,
+    "preview_ready": true,
+    "no_drops": true
+  }
+}
+```
+
+Receipts are the main handoff point between firmware, Labs users, and host-side
+validation tools.
+
+## C ABI Sketch
+
+The C ABI is specified in
+`source/lib/gpr_sdk/public/gpr_labs_extension_api.h`. The header is a proposal
+surface only; this PR does not wire it into the SDK build.
+
+The ABI is designed around five operations:
+
+1. Query static capabilities.
+2. Open a capture session.
+3. Encode one raw frame into the extension output.
+4. Decode or render one preview frame.
+5. Close the session and return a receipt summary.
+
+The firmware owns memory, source buffers, storage, and UI surfaces. The
+extension receives bounded descriptors and returns status codes.
+
+## Upstream Review Questions
+
+- Should this live in Labs only, Open GoPro only, or both?
+- Should Phase 1 allow native modules, or only signed data/tuning bundles that
+  activate code already compiled into Labs firmware?
+- Which camera-model identifiers and capability strings should be canonical?
+- Should receipts be stored as sidecar JSON files, exposed through Open GoPro,
+  embedded in media metadata, or all three?
+- Which resource limits should be mandatory for embedded capture acceptance?
+
+## References
+
+- GoPro Labs: https://gopro.com/en/us/info/gopro-labs
+- Labs QR control: https://gopro.github.io/labs/control/
+- Open GoPro: https://gopro.github.io/OpenGoPro/docs/

--- a/docs/MISSION1_LABS_INTEGRATION_PROPOSAL.md
+++ b/docs/MISSION1_LABS_INTEGRATION_PROPOSAL.md
@@ -1,0 +1,127 @@
+# Mission 1 Labs Raw Video Integration Proposal
+
+This document describes how a raw Bayer video experiment could be integrated
+into Labs firmware without requiring a general-purpose firmware plugin system.
+
+The proposal is intentionally conservative: GoPro can adopt the command,
+manifest, receipt, and resource-limit contracts first, then decide later
+whether signed extension bundles are appropriate.
+
+## Broader Fork Context
+
+The upstream-facing proposal is a narrow Labs integration path, but the fork it
+comes from is broader than raw video alone:
+
+- GPR stills work now includes production-gated 50 MP tiers around 9.8 MB,
+  15.1 MB, and 27.2 MB per frame.
+- The stills path uses a matched Bayer-domain 1x CNN to preserve visual quality
+  at lower file sizes, while the highest-quality still tier passes without CNN
+  restoration.
+- The raw format work includes 14-bit and 16-bit Bayer handling, so the same
+  family of tools can cover newer high-resolution sensors instead of being
+  limited to older 12-bit still paths.
+- The video work adds an independently decodable `.gvid` container, camera
+  display preview target, host-side editable DNG/GPR export, and offline 4K/8K
+  CNN reconstruction experiments.
+
+Those pieces do not all need to land in one upstream change. The proposed first
+step is the small firmware contract that would let GoPro evaluate raw video,
+preview, storage, and receipts with normal Labs safety boundaries.
+
+## Proposed First Milestone
+
+Compile a GPR/GVID raw-video experiment into Labs firmware and expose it through
+Labs/Open GoPro commands:
+
+```text
+mode: gvid_4k_bayer_20
+input: sensor Bayer frame source
+output: .gvid file on camera storage
+preview: 1024 x 768 RGB camera display surface
+target: 20 fps or higher on Mission 1 class hardware
+```
+
+The feature should remain hidden unless explicitly enabled by Labs/Open GoPro.
+
+## Host-To-Camera Flow
+
+1. User installs Labs firmware.
+2. User sends a Labs QR/script command or Open GoPro request selecting
+   `org.gpr.gvid`.
+3. Firmware validates that the extension mode is supported on the camera.
+4. Firmware starts raw frame capture and writes `.gvid`.
+5. Firmware renders a preview from the same `.gvid` stream or from the same raw
+   frame source.
+6. Firmware writes a capture receipt.
+7. Host tools download `.gvid` and receipts over USB/Wi-Fi for review/export.
+
+## Why Not A General Plugin Loader First?
+
+Native downloadable modules create security, reliability, and support issues:
+
+- Signature and rollback policy.
+- ABI compatibility across firmware versions.
+- Power-loss safety during install/update.
+- Resource containment for CPU, RAM, storage, and thermal budget.
+- Crash isolation from capture and media indexing.
+
+A statically compiled Labs feature with a manifest-like contract gives most of
+the review value without those risks.
+
+## Extension Bundle Future
+
+If GoPro later wants installable extensions, the same manifest can become the
+bundle descriptor. The firmware should only load signed bundles whose manifests
+declare supported camera models, ABI version, required capabilities, and
+resource limits.
+
+Recommended bundle install path:
+
+```text
+USB/Wi-Fi upload -> staging area -> signature validation -> compatibility
+check -> inactive install slot -> explicit user activation
+```
+
+Recommended failure behavior:
+
+- Never activate an unverified bundle.
+- Keep the previous working bundle.
+- Emit an install receipt with a human-readable rejection reason.
+
+## Acceptance Receipts
+
+For a raw-video Labs feature, production review should require receipts for:
+
+| receipt | proves |
+|---|---|
+| `capture_receipt.json` | Sensor/DMA frame source, output dimensions, pixel format, frame count, dropped frames, write throughput, and FPS. |
+| `preview_receipt.json` | Preview dimensions, preview FPS, and UI/display presentation status. |
+| `recovery_receipt.json` | The `.gvid` stream can recover the last complete frame after interrupted capture. |
+| `extension_receipt.json` | Manifest hash, ABI version, camera model, firmware version, and resource limits. |
+
+The capture receipt should also record raw bit depth, Bayer phase, black/white
+levels, and whether the source is 14-bit or 16-bit so host tools can export
+editable DNG/GPR without guessing camera metadata.
+
+## Minimal Upstream PR Contents
+
+This PR intentionally proposes the contract rather than a complete camera
+firmware feature:
+
+- `docs/LABS_RAW_MEDIA_EXTENSION_API.md`
+- `docs/GVID_CONTAINER.md`
+- `docs/MISSION1_LABS_INTEGRATION_PROPOSAL.md`
+- `source/lib/gpr_sdk/public/gpr_labs_extension_api.h`
+- `examples/labs/raw_media_extension_gvid.json`
+- `tools/validate_labs_extension_manifest.py`
+
+## Open Questions For GoPro
+
+- Should Labs extensions be controlled through QR/Labs commands, Open GoPro
+  HTTP, or both?
+- Should signed bundles ever include native code, or should bundles only carry
+  data/configuration for code already present in Labs firmware?
+- Which receipt fields are required for a Labs feature to graduate from
+  experiment to supported mode?
+- Should `.gvid` be a Labs-only experimental container name, or should it be
+  formalized as part of the GPR project?

--- a/examples/labs/raw_media_extension_gvid.json
+++ b/examples/labs/raw_media_extension_gvid.json
@@ -1,0 +1,75 @@
+{
+  "schema": "gopro.labs.raw_media_extension.v1",
+  "id": "org.gpr.gvid",
+  "name": "GPR Raw Video",
+  "abi": 1,
+  "delivery": "static_labs_feature",
+  "camera_models": [
+    "MISSION1",
+    "MISSION1_PRO"
+  ],
+  "requires": [
+    "raw_bayer_frame_source",
+    "sd_writer",
+    "preview_surface",
+    "media_indexer",
+    "receipt_writer"
+  ],
+  "media_types": [
+    ".gvid"
+  ],
+  "capture_modes": [
+    {
+      "id": "gvid_4k_bayer_20",
+      "description": "4096 x 3072 Bayer raw video with camera-display preview",
+      "width": 4096,
+      "height": 3072,
+      "fps_floor": 20,
+      "pixel_format": "rggb16",
+      "bit_depth": 16,
+      "payload_kind": "gpr_vc5_frame",
+      "preview": {
+        "width": 1024,
+        "height": 768,
+        "format": "rgb888",
+        "fps_floor": 20
+      }
+    }
+  ],
+  "resource_limits": {
+    "max_rss_mb": 256,
+    "max_frame_time_ms": 50,
+    "max_write_mbps": 135,
+    "max_dropped_frames": 0
+  },
+  "control": {
+    "labs_commands": [
+      "EXT?",
+      "EXT=org.gpr.gvid",
+      "EXTC=mode:gvid_4k_bayer_20",
+      "EXTR=1",
+      "EXTR=0",
+      "EXTS?"
+    ],
+    "open_gopro_http": [
+      "GET /gopro/labs/extensions",
+      "GET /gopro/labs/extensions/org.gpr.gvid",
+      "POST /gopro/labs/extensions/org.gpr.gvid/configure",
+      "POST /gopro/labs/extensions/org.gpr.gvid/capture/start",
+      "POST /gopro/labs/extensions/org.gpr.gvid/capture/stop",
+      "GET /gopro/labs/extensions/org.gpr.gvid/status",
+      "GET /gopro/labs/extensions/org.gpr.gvid/receipt/latest"
+    ]
+  },
+  "receipts": {
+    "capture": "gopro.labs.raw_media_capture_receipt.v1",
+    "preview": "gopro.labs.raw_media_preview_receipt.v1",
+    "install": "gopro.labs.extension_install_receipt.v1"
+  },
+  "security": {
+    "signature_required": true,
+    "native_code_allowed": false,
+    "rollback_protection": true,
+    "resource_limits_enforced": true
+  }
+}

--- a/source/lib/gpr_sdk/public/gpr_labs_extension_api.h
+++ b/source/lib/gpr_sdk/public/gpr_labs_extension_api.h
@@ -1,0 +1,179 @@
+/*! @file gpr_labs_extension_api.h
+ *
+ *  @brief Draft Labs raw media extension ABI.
+ *
+ *  This header is a proposal surface for Labs firmware review. It is not wired
+ *  into the SDK build by this change.
+ *
+ *  (C) Copyright 2026.
+ *
+ *  Licensed under either:
+ *  - Apache License, Version 2.0, http://www.apache.org/licenses/LICENSE-2.0
+ *  - MIT license, http://opensource.org/licenses/MIT
+ *  at your option.
+ */
+
+#ifndef GPR_LABS_EXTENSION_API_H
+#define GPR_LABS_EXTENSION_API_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define GPR_LABS_EXTENSION_ABI_VERSION 1
+#define GPR_LABS_EXTENSION_ID_SIZE 64
+#define GPR_LABS_EXTENSION_NAME_SIZE 64
+#define GPR_LABS_EXTENSION_MODE_SIZE 64
+#define GPR_LABS_EXTENSION_ERROR_SIZE 128
+#define GPR_LABS_BIT_DEPTH_14_MASK (1u << 14)
+#define GPR_LABS_BIT_DEPTH_16_MASK (1u << 16)
+
+typedef enum
+{
+    GPR_LABS_STATUS_OK = 0,
+    GPR_LABS_STATUS_UNSUPPORTED_ABI = 1,
+    GPR_LABS_STATUS_UNSUPPORTED_MODE = 2,
+    GPR_LABS_STATUS_INVALID_ARGUMENT = 3,
+    GPR_LABS_STATUS_RESOURCE_LIMIT = 4,
+    GPR_LABS_STATUS_IO_ERROR = 5,
+    GPR_LABS_STATUS_INTERNAL_ERROR = 6,
+} gpr_labs_status;
+
+typedef enum
+{
+    GPR_LABS_PIXEL_FORMAT_RGGB14 = 1,
+    GPR_LABS_PIXEL_FORMAT_GBRG14 = 2,
+    GPR_LABS_PIXEL_FORMAT_BGGR14 = 3,
+    GPR_LABS_PIXEL_FORMAT_GRBG14 = 4,
+    GPR_LABS_PIXEL_FORMAT_RGGB16 = 5,
+    GPR_LABS_PIXEL_FORMAT_GBRG16 = 6,
+    GPR_LABS_PIXEL_FORMAT_BGGR16 = 7,
+    GPR_LABS_PIXEL_FORMAT_GRBG16 = 8,
+} gpr_labs_pixel_format;
+
+typedef enum
+{
+    GPR_LABS_SOURCE_SENSOR_DMA_CAPTURE = 1,
+    GPR_LABS_SOURCE_CAMERA_RING_BUFFER = 2,
+    GPR_LABS_SOURCE_FILE_STANDIN = 3,
+} gpr_labs_raw_source_kind;
+
+typedef struct
+{
+    uint32_t abi_version;
+    char extension_id[GPR_LABS_EXTENSION_ID_SIZE];
+    char extension_name[GPR_LABS_EXTENSION_NAME_SIZE];
+    uint32_t mode_count;
+    uint32_t requires_raw_bayer_frame_source;
+    uint32_t requires_sd_writer;
+    uint32_t requires_preview_surface;
+    uint32_t max_width;
+    uint32_t max_height;
+    uint32_t supported_bit_depth_mask;
+    uint32_t max_fps_num;
+    uint32_t max_fps_den;
+    uint32_t max_rss_mb;
+    uint32_t max_frame_time_us;
+    uint32_t max_write_mbps;
+} gpr_labs_extension_caps;
+
+typedef struct
+{
+    char mode_id[GPR_LABS_EXTENSION_MODE_SIZE];
+    uint32_t width;
+    uint32_t height;
+    uint32_t fps_num;
+    uint32_t fps_den;
+    gpr_labs_pixel_format pixel_format;
+    uint32_t bit_depth;
+    gpr_labs_raw_source_kind source_kind;
+    uint32_t preview_width;
+    uint32_t preview_height;
+    uint32_t max_frame_time_us;
+    uint32_t max_write_mbps;
+} gpr_labs_capture_config;
+
+typedef struct
+{
+    const void* data;
+    uint32_t size_bytes;
+    uint32_t stride_bytes;
+    uint64_t timestamp_us;
+    uint32_t frame_number;
+} gpr_labs_raw_frame;
+
+typedef struct
+{
+    void* data;
+    uint32_t capacity_bytes;
+    uint32_t bytes_written;
+} gpr_labs_output_buffer;
+
+typedef struct
+{
+    void* rgba_or_rgb_data;
+    uint32_t width;
+    uint32_t height;
+    uint32_t stride_bytes;
+    uint32_t format;
+} gpr_labs_preview_surface;
+
+typedef struct
+{
+    uint32_t frames_written;
+    uint32_t frames_dropped;
+    uint32_t width;
+    uint32_t height;
+    uint32_t preview_width;
+    uint32_t preview_height;
+    uint32_t fps_num;
+    uint32_t fps_den;
+    uint32_t median_frame_time_us;
+    uint32_t wall_frame_time_us;
+    uint32_t write_mbps;
+    uint32_t max_rss_mb;
+    uint32_t output_valid;
+    uint32_t preview_presented;
+    char last_error[GPR_LABS_EXTENSION_ERROR_SIZE];
+} gpr_labs_capture_receipt;
+
+typedef struct gpr_labs_extension_session gpr_labs_extension_session;
+
+typedef gpr_labs_status (*gpr_labs_query_caps_fn)(
+    gpr_labs_extension_caps* caps);
+
+typedef gpr_labs_status (*gpr_labs_open_capture_fn)(
+    const gpr_labs_capture_config* config,
+    gpr_labs_extension_session** session);
+
+typedef gpr_labs_status (*gpr_labs_encode_frame_fn)(
+    gpr_labs_extension_session* session,
+    const gpr_labs_raw_frame* frame,
+    gpr_labs_output_buffer* output);
+
+typedef gpr_labs_status (*gpr_labs_render_preview_fn)(
+    gpr_labs_extension_session* session,
+    const gpr_labs_raw_frame* frame,
+    gpr_labs_preview_surface* preview);
+
+typedef gpr_labs_status (*gpr_labs_close_capture_fn)(
+    gpr_labs_extension_session* session,
+    gpr_labs_capture_receipt* receipt);
+
+typedef struct
+{
+    uint32_t abi_version;
+    gpr_labs_query_caps_fn query_caps;
+    gpr_labs_open_capture_fn open_capture;
+    gpr_labs_encode_frame_fn encode_frame;
+    gpr_labs_render_preview_fn render_preview;
+    gpr_labs_close_capture_fn close_capture;
+} gpr_labs_extension_api;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPR_LABS_EXTENSION_API_H */

--- a/tools/test_validate_labs_extension_manifest.py
+++ b/tools/test_validate_labs_extension_manifest.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Regression tests for Labs extension manifest validation."""
+from __future__ import annotations
+
+import copy
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / "tools/validate_labs_extension_manifest.py"
+SAMPLE = ROOT / "examples/labs/raw_media_extension_gvid.json"
+
+
+def import_tool():
+    spec = importlib.util.spec_from_file_location("validate_labs_extension_manifest_under_test", TOOL)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_sample() -> dict:
+    import json
+
+    with SAMPLE.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert isinstance(data, dict)
+    return data
+
+
+def expect_failure(module, data: dict, text: str) -> None:
+    failures = module.validate_manifest(data)
+    if not any(text in failure for failure in failures):
+        raise AssertionError(f"expected failure containing {text!r}, got {failures!r}")
+
+
+def main() -> int:
+    module = import_tool()
+    sample = load_sample()
+    failures = module.validate_manifest(sample)
+    if failures:
+        print(f"sample manifest unexpectedly failed: {failures}", file=sys.stderr)
+        return 1
+
+    no_signature = copy.deepcopy(sample)
+    no_signature["security"]["signature_required"] = False
+    expect_failure(module, no_signature, "signature_required")
+
+    native_code = copy.deepcopy(sample)
+    native_code["security"]["native_code_allowed"] = True
+    expect_failure(module, native_code, "native_code_allowed")
+
+    missing_capability = copy.deepcopy(sample)
+    missing_capability["requires"].remove("preview_surface")
+    expect_failure(module, missing_capability, "missing capabilities")
+
+    oversized_preview = copy.deepcopy(sample)
+    oversized_preview["capture_modes"][0]["preview"]["width"] = 9999
+    expect_failure(module, oversized_preview, "preview.width")
+
+    mismatched_bit_depth = copy.deepcopy(sample)
+    mismatched_bit_depth["capture_modes"][0]["bit_depth"] = 14
+    expect_failure(module, mismatched_bit_depth, "pixel_format must match bit_depth")
+
+    print("test_validate_labs_extension_manifest: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_labs_extension_manifest.py
+++ b/tools/validate_labs_extension_manifest.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Validate a Labs raw media extension manifest."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "gopro.labs.raw_media_extension.v1"
+DELIVERY_VALUES = {"static_labs_feature", "signed_bundle", "firmware_builtin"}
+REQUIRED_CAPABILITIES = {
+    "raw_bayer_frame_source",
+    "sd_writer",
+    "preview_surface",
+    "media_indexer",
+    "receipt_writer",
+}
+PIXEL_FORMATS = {
+    "rggb14",
+    "gbrg14",
+    "bggr14",
+    "grbg14",
+    "rggb16",
+    "gbrg16",
+    "bggr16",
+    "grbg16",
+}
+BIT_DEPTHS = {14, 16}
+PAYLOAD_KINDS = {"gpr_vc5_frame", "raw16_frame"}
+
+
+def require(condition: bool, failures: list[str], message: str) -> None:
+    if not condition:
+        failures.append(message)
+
+
+def is_nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def is_positive_int(value: Any) -> bool:
+    return isinstance(value, int) and value > 0
+
+
+def validate_capture_mode(mode: Any, failures: list[str], index: int) -> None:
+    prefix = f"capture_modes[{index}]"
+    if not isinstance(mode, dict):
+        failures.append(f"{prefix} must be an object")
+        return
+
+    for key in ("id", "description", "pixel_format", "payload_kind"):
+        require(is_nonempty_string(mode.get(key)), failures, f"{prefix}.{key} must be a non-empty string")
+    for key in ("width", "height", "fps_floor"):
+        require(is_positive_int(mode.get(key)), failures, f"{prefix}.{key} must be a positive integer")
+
+    if is_nonempty_string(mode.get("pixel_format")):
+        require(mode["pixel_format"] in PIXEL_FORMATS, failures, f"{prefix}.pixel_format is not supported")
+    require(mode.get("bit_depth") in BIT_DEPTHS, failures, f"{prefix}.bit_depth must be one of {sorted(BIT_DEPTHS)}")
+    if is_nonempty_string(mode.get("pixel_format")) and mode.get("bit_depth") in BIT_DEPTHS:
+        require(mode["pixel_format"].endswith(str(mode["bit_depth"])), failures, f"{prefix}.pixel_format must match bit_depth")
+    if is_nonempty_string(mode.get("payload_kind")):
+        require(mode["payload_kind"] in PAYLOAD_KINDS, failures, f"{prefix}.payload_kind is not supported")
+
+    preview = mode.get("preview")
+    if not isinstance(preview, dict):
+        failures.append(f"{prefix}.preview must be an object")
+        return
+    for key in ("width", "height", "fps_floor"):
+        require(is_positive_int(preview.get(key)), failures, f"{prefix}.preview.{key} must be a positive integer")
+    require(is_nonempty_string(preview.get("format")), failures, f"{prefix}.preview.format must be a non-empty string")
+
+    if is_positive_int(mode.get("width")) and is_positive_int(preview.get("width")):
+        require(preview["width"] <= mode["width"], failures, f"{prefix}.preview.width must not exceed capture width")
+    if is_positive_int(mode.get("height")) and is_positive_int(preview.get("height")):
+        require(preview["height"] <= mode["height"], failures, f"{prefix}.preview.height must not exceed capture height")
+
+
+def validate_manifest(data: Any) -> list[str]:
+    failures: list[str] = []
+    if not isinstance(data, dict):
+        return ["manifest must be a JSON object"]
+
+    require(data.get("schema") == SCHEMA, failures, f"schema must be {SCHEMA}")
+    require(is_nonempty_string(data.get("id")), failures, "id must be a non-empty string")
+    require(is_nonempty_string(data.get("name")), failures, "name must be a non-empty string")
+    require(is_positive_int(data.get("abi")), failures, "abi must be a positive integer")
+    require(data.get("delivery") in DELIVERY_VALUES, failures, "delivery must be a supported value")
+
+    camera_models = data.get("camera_models")
+    require(isinstance(camera_models, list) and bool(camera_models), failures, "camera_models must be a non-empty list")
+    if isinstance(camera_models, list):
+        for idx, value in enumerate(camera_models):
+            require(is_nonempty_string(value), failures, f"camera_models[{idx}] must be a non-empty string")
+
+    requires = data.get("requires")
+    require(isinstance(requires, list) and bool(requires), failures, "requires must be a non-empty list")
+    if isinstance(requires, list):
+        missing = REQUIRED_CAPABILITIES - set(requires)
+        require(not missing, failures, "requires is missing capabilities: " + ", ".join(sorted(missing)))
+
+    media_types = data.get("media_types")
+    require(isinstance(media_types, list) and ".gvid" in media_types, failures, "media_types must include .gvid")
+
+    modes = data.get("capture_modes")
+    require(isinstance(modes, list) and bool(modes), failures, "capture_modes must be a non-empty list")
+    if isinstance(modes, list):
+        seen: set[str] = set()
+        for idx, mode in enumerate(modes):
+            validate_capture_mode(mode, failures, idx)
+            if isinstance(mode, dict) and is_nonempty_string(mode.get("id")):
+                require(mode["id"] not in seen, failures, f"duplicate capture mode id: {mode['id']}")
+                seen.add(mode["id"])
+
+    limits = data.get("resource_limits")
+    if not isinstance(limits, dict):
+        failures.append("resource_limits must be an object")
+    else:
+        for key in ("max_rss_mb", "max_frame_time_ms", "max_write_mbps", "max_dropped_frames"):
+            require(isinstance(limits.get(key), int) and limits[key] >= 0, failures, f"resource_limits.{key} must be a non-negative integer")
+        require(limits.get("max_dropped_frames") == 0, failures, "resource_limits.max_dropped_frames must be 0 for raw capture promotion")
+
+    control = data.get("control")
+    if not isinstance(control, dict):
+        failures.append("control must be an object")
+    else:
+        require(isinstance(control.get("labs_commands"), list) and bool(control.get("labs_commands")), failures, "control.labs_commands must be a non-empty list")
+        require(isinstance(control.get("open_gopro_http"), list) and bool(control.get("open_gopro_http")), failures, "control.open_gopro_http must be a non-empty list")
+
+    receipts = data.get("receipts")
+    if not isinstance(receipts, dict):
+        failures.append("receipts must be an object")
+    else:
+        for key in ("capture", "preview", "install"):
+            require(is_nonempty_string(receipts.get(key)), failures, f"receipts.{key} must be a non-empty string")
+
+    security = data.get("security")
+    if not isinstance(security, dict):
+        failures.append("security must be an object")
+    else:
+        require(security.get("signature_required") is True, failures, "security.signature_required must be true")
+        require(security.get("native_code_allowed") is False, failures, "security.native_code_allowed must be false for the initial proposal")
+        require(security.get("rollback_protection") is True, failures, "security.rollback_protection must be true")
+        require(security.get("resource_limits_enforced") is True, failures, "security.resource_limits_enforced must be true")
+
+    return failures
+
+
+def parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("manifest", type=Path)
+    return ap
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        data = json.loads(args.manifest.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"could not load manifest: {exc}", file=sys.stderr)
+        return 1
+
+    failures = validate_manifest(data)
+    if failures:
+        print("Labs extension manifest validation failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+    print(f"OK - Labs extension manifest valid: {args.manifest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Note: see the README on my Fork for a real view into what I have done. 
https://github.com/dcliftreaves/gpr

## Summary

This proposes a small Labs-facing raw media extension contract rather than a full firmware feature. The goal is to give GoPro a reviewable interface for experimental raw media modes while keeping firmware in control of capture, storage, UI, power, resource limits, and receipts.

Included in this PR:

- `docs/LABS_RAW_MEDIA_EXTENSION_API.md`: extension manifest, Labs/Open GoPro control surface, receipts, deployment model, and review questions
- `docs/GVID_CONTAINER.md`: simple independently-decodable raw Bayer video container sketch
- `docs/MISSION1_LABS_INTEGRATION_PROPOSAL.md`: conservative Mission 1 first milestone for raw Bayer `.gvid` capture and camera preview
- `source/lib/gpr_sdk/public/gpr_labs_extension_api.h`: draft C ABI surface for firmware review
- `examples/labs/raw_media_extension_gvid.json`: sample extension manifest
- `tools/validate_labs_extension_manifest.py` and test coverage

## Why this fork may be interesting

The broader fork work goes beyond this narrow API proposal:

- Production-gated GPR still tiers for 50 MP images around 9.8 MB, 15.1 MB, and 27.2 MB per frame
- Matched Bayer-domain 1x CNN restoration that gives still users more compression latitude at lower file sizes
- Raw Bayer video via `.gvid`, with one independently decodable GPR/VC-5-style payload per frame and no cross-frame dependency
- Camera-display preview from the same raw media path, with receipts for FPS, dimensions, drops, and UI presentation
- 14-bit and 16-bit Bayer paths for larger modern sensors and higher raw editing latitude
- Host-side 4K/8K CNN cleanup/SR experiments that preserve editable Bayer outputs and ProRes review workflows

This PR does not ask GoPro to accept all of that in one change. It proposes the minimal firmware/API contract needed to evaluate those ideas safely in Labs-style constraints.

## Validation

- `python3 tools/validate_labs_extension_manifest.py examples/labs/raw_media_extension_gvid.json`
- `python3 tools/test_validate_labs_extension_manifest.py`
- `git diff --check`

## Notes

- This does not introduce a general unsigned plugin loader.
- This does not require third-party code execution on production cameras.
- This does not wire the draft ABI into the SDK build.
- The initial proposed delivery model is a statically compiled Labs feature, with signed bundles left as a future design question.
